### PR TITLE
dont set max height

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,9 +115,6 @@ class Indicator extends PanelMenu.Button {
       section1.addMenuItem(menuItem);
     });
     this.menu.box.add_child(scrollView);
-    this.menu.box.style = `
-        max-height: 12em;
-    `;
   }
 }
 


### PR DESCRIPTION
I love your extension! Use it almost every day - love the simplicity of it

One nit, is when I add more stations I get a scrollbar and the window stays smal

I did a quick test, and this small change seems to work well


current
---
![image](https://github.com/EuCaue/gnome-shell-extension-quick-lofi/assets/50854675/7fc80890-bcb8-409c-9245-5af12994be92)

this pr
---
![image](https://github.com/EuCaue/gnome-shell-extension-quick-lofi/assets/50854675/53e28007-de17-4a13-8d7d-4210157cc57d)
